### PR TITLE
fix(ci): ignore generated build files in README check

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -188,7 +188,7 @@ jobs:
           branch="automation/virustotal-${RELEASE_TAG}"
           git switch --create "${branch}"
           git add README.md README/
-          if git diff-index --quiet HEAD; then
+          if git diff --cached --quiet; then
             echo "No VirusTotal README changes to commit."
             exit 0
           fi


### PR DESCRIPTION
The release workflow stages only README files, but the build also changes generated Version and installer files. Check the staged index so the README commit step exits cleanly when no README changes are present.